### PR TITLE
Fix bani lines query

### DIFF
--- a/app/lib/db.js
+++ b/app/lib/db.js
@@ -55,10 +55,8 @@ export const getBanis = () => Banis.query()
  */
 export const getBaniLines = baniId => Banis
   .query()
-  .eager( 'lines' )
-  .modifyEager( 'lines', builder => {
-    builder.orderBy( [ 'line_group', 'line_id' ] )
-  } )
+  .joinEager( 'lines' )
+  .orderBy( [ 'line_group', 'order_id' ] )
   .where( 'banis.id', baniId )
   .withTranslations()
   .withTransliterations()


### PR DESCRIPTION
Sort lines by Bani Line's line group and Line's order id.

Notes:

* line_id seems to be a non-integer reference. Used to be integer in @shabados/database@3.0.0.
* Forces join eager algorithm.
* Why the query used to work? Builder on eager makes the orderBy only work on the left join query. @shabados/database@3.0.0 used to do the Bani_Lines/Lines via innerjoin. I think that's why the older query worked. Also, that query was only doing Bani Lines. This query also gets Bani document along with Lines documents.