### PR TITLE
fix(frontend/presenter): allow flexible font-sizing

### DIFF
--- a/app/frontend/src/Presenter/Line.css
+++ b/app/frontend/src/Presenter/Line.css
@@ -43,6 +43,7 @@
 
 .line .gurmukhi {
     font-family: "Open Gurbani Akhar Black", sans-serif;
+    font-size: 1em;
     line-height: 1.4;
 }
 
@@ -52,7 +53,7 @@
 
 .line .english {
     font-family: "Noto Sans Medium", sans-serif;
-    font-size: 4.740740741vh;
+    font-size: 0.592592592625em;
     line-height: 1.89;
     line-height: 1.4;
     font-weight: 700;
@@ -60,7 +61,7 @@
 
 .line .punjabi {
     font-family: "Open Anmol Uni Bold", sans-serif;
-    font-size: 5.555555555vh;
+    font-size: 0.694444444375em;
     line-height: 2.025;
     line-height: 1.75;
     line-height: 1.5;
@@ -78,11 +79,11 @@
 }
 
 .line .gurmukhi .word {
-    margin-right: 2.25vh;
+    margin-right: 0.28125em;
 }
 
 .line .transliteration .word {
-    margin-right: 0.8vh;
+    margin-right: 0.25em;
 }
 
 .larivaar.line .word {
@@ -114,7 +115,7 @@
 
 .line .transliteration {
     font-family: "Noto Sans Regular", sans-serif;
-    font-size: 3.5vh;
+    font-size: 0.4375em;
     color: var(--display-transliteration-color);
     transition: 0.2s all ease-in;
   }

--- a/app/frontend/src/lib/consts.js
+++ b/app/frontend/src/lib/consts.js
@@ -189,7 +189,7 @@ export const OPTIONS = {
   englishTransliteration: { name: 'English Transliteration', icon: farClosedCaptioning, type: OPTION_TYPES.toggle, privacy: PRIVACY_TYPES.local },
   previousLines: { name: 'Previous Lines', icon: faAlignJustify, type: OPTION_TYPES.slider, max: 5, step: 1, privacy: PRIVACY_TYPES.local },
   nextLines: { name: 'Next Lines', icon: faAlignJustify, type: OPTION_TYPES.slider, max: 5, step: 1, privacy: PRIVACY_TYPES.local },
-  fontSize: { name: 'Font Size', icon: faFont, type: OPTION_TYPES.slider, min: 1, max: 32, step: 1, privacy: PRIVACY_TYPES.local },
+  fontSize: { name: 'Font Size', icon: faFont, type: OPTION_TYPES.slider, min: 3, max: 13, step: 0.1, privacy: PRIVACY_TYPES.local },
   themeName: { name: 'Theme Name', icon: faPalette, type: OPTION_TYPES.dropdown, values: [], privacy: PRIVACY_TYPES.local },
   backgroundImage: { name: 'Background Image', icon: faImage, type: OPTION_TYPES.toggle, privacy: PRIVACY_TYPES.local },
   simpleGraphics: { name: 'Simple Graphics', icon: faLowVision, type: OPTION_TYPES.toggle, privacy: PRIVACY_TYPES.local },


### PR DESCRIPTION
the previous implementation was in hard vh units, since switching to a master font-slider, we need to use flexible units of measure in the line

this also fixes word-spacing issues and allows for more fine-tuned font-size changes

Related #75 #191