### PR TITLE
feat(frontend): add theme colors to material ui

### DIFF
--- a/app/electron/electron-wrapper.js
+++ b/app/electron/electron-wrapper.js
@@ -32,6 +32,7 @@ function createWindow() {
   loadPage()
 
   mainWindow.on( 'ready-to-show', () => {
+    mainWindow.setMenuBarVisibility( isDev ? true : false )
     mainWindow.maximize()
     mainWindow.show()
     mainWindow.focus()

--- a/app/frontend/src/Presenter/Line.css
+++ b/app/frontend/src/Presenter/Line.css
@@ -112,7 +112,7 @@
 
 .line .transliteration {
   font-family: "Noto Sans Regular", sans-serif;
-  font-size: 0.4375em;
+  font-size: 0.592592592625em;
   color: var(--display-transliteration-color);
   transition: 0.2s all ease-in;
 }

--- a/app/frontend/src/Settings/SettingComponents.css
+++ b/app/frontend/src/Settings/SettingComponents.css
@@ -10,11 +10,11 @@
 }
 
 .select::after {
-  border-bottom: 2px solid var(--settings-setting-color) !important;
+  border-bottom: 2px solid var(--settings-setting-on) !important;
 }
 
 .select-menu ul {
-  background-color: var(--settings-background-color);
+  background-color: var(--settings-setting-off);
 }
 
 .select-menu li {
@@ -27,11 +27,11 @@
 
 .checked.toggle > span,
 .slider {
-  color: var(--settings-setting-color) !important;
+  color: var(--settings-setting-on) !important;
 }
 
 .checked.toggle > span:last-child {
-  background-color: var(--settings-setting-color);
+  background-color: var(--settings-setting-on);
 }
 
 .checked.toggle > :hover {
@@ -40,4 +40,23 @@
 
 .slider .MuiSlider-thumb:hover, .slider .MuiSlider-thumb.MuiSlider-active {
   box-shadow: 0px 0px 0px 8px var(--settings-setting-shadow) !important;
+}
+.MuiPopover-paper .MuiListItem-root.Mui-selected {
+  background-color: var(--controller-selected-background-color);
+}
+
+.MuiPopover-paper .MuiListItem-button:hover {
+  background-color: var(--controller-hover-background-color);
+}
+
+.MuiPopover-paper .MuiListItem-root.Mui-selected:hover {
+  background-color: var(--controller-selected-hover-background-color);
+}
+
+.MuiInput-root .MuiSelect-select:focus {
+  background-color: transparent;
+}
+
+.MuiSwitch-switchBase {
+  color: var(--settings-setting-off) !important;
 }

--- a/app/frontend/src/Settings/SettingComponents.css
+++ b/app/frontend/src/Settings/SettingComponents.css
@@ -10,11 +10,11 @@
 }
 
 .select::after {
-  border-bottom: 2px solid var(--settings-setting-on) !important;
+  border-bottom: 2px solid var(--settings-setting-on-color) !important;
 }
 
 .select-menu ul {
-  background-color: var(--settings-setting-off);
+  background-color: var(--settings-setting-off-color);
 }
 
 .select-menu li {
@@ -27,11 +27,11 @@
 
 .checked.toggle > span,
 .slider {
-  color: var(--settings-setting-on) !important;
+  color: var(--settings-setting-on-color) !important;
 }
 
 .checked.toggle > span:last-child {
-  background-color: var(--settings-setting-on);
+  background-color: var(--settings-setting-on-color);
 }
 
 .checked.toggle > :hover {
@@ -58,5 +58,5 @@
 }
 
 .MuiSwitch-switchBase {
-  color: var(--settings-setting-off) !important;
+  color: var(--settings-setting-off-color) !important;
 }

--- a/app/frontend/src/Settings/SettingComponents.css
+++ b/app/frontend/src/Settings/SettingComponents.css
@@ -41,6 +41,7 @@
 .slider .MuiSlider-thumb:hover, .slider .MuiSlider-thumb.MuiSlider-active {
   box-shadow: 0px 0px 0px 8px var(--settings-setting-shadow) !important;
 }
+
 .MuiPopover-paper .MuiListItem-root.Mui-selected {
   background-color: var(--controller-selected-background-color);
 }

--- a/app/frontend/src/Settings/Sources.css
+++ b/app/frontend/src/Settings/Sources.css
@@ -1,5 +1,5 @@
 .sources .source {
-  background-color: var(--settings-setting-off);
+  background-color: var(--settings-setting-off-color);
 }
 
 .sources .source .gurmukhi {

--- a/app/frontend/src/Settings/Sources.css
+++ b/app/frontend/src/Settings/Sources.css
@@ -1,5 +1,5 @@
 .sources .source {
-  background-color: var(--settings-menu-background-color);
+  background-color: var(--settings-setting-off);
 }
 
 .sources .source .gurmukhi {

--- a/app/frontend/src/shared/Loader.css
+++ b/app/frontend/src/shared/Loader.css
@@ -21,10 +21,10 @@
   width: 0.8em;
   height: 0.8em;
   margin: 0.1em;
-  border: 0.1em solid #db5c87;
+  border: 0.1em solid var(--controller-search-match-color);
   border-radius: 50%;
   animation: lds-ring 1.2s cubic-bezier(0.5, 0, 0.5, 1) infinite;
-  border-color: #db5c87 transparent transparent transparent;
+  border-color: var(--controller-search-match-color) transparent transparent transparent;
 }
 
 .loader .lds-ring div:nth-child(1) {

--- a/app/frontend/src/themes/Avani.css
+++ b/app/frontend/src/themes/Avani.css
@@ -78,8 +78,8 @@
     /* Settings Content */
     --settings-background-color: var(--controller-background-color);
     --settings-text-color: var(--controller-text-color);
-    --settings-setting-off: #F6F3EF;
-    --settings-setting-on: var(--controller-search-match-color);
+    --settings-setting-off-color: #F6F3EF;
+    --settings-setting-on-color: var(--controller-search-match-color);
     --settings-setting-shadow: #00558331;
 
       /*****************/

--- a/app/frontend/src/themes/Avani.css
+++ b/app/frontend/src/themes/Avani.css
@@ -44,23 +44,23 @@
     /**************/
 
     /* Controller colors */
-    --controller-background-color: #bdb3b5; /* EFE6E7 at 74% opacity on 2d2026 bg */
-    --controller-text-color: #403338;
-    --controller-text-hover-color: #491D2E;
-    --controller-selected-color: #2D2026;
-    --controller-selected-background-color: #f2eef0;
-    --controller-hover-background-color: #d3cbcd;
-    --controller-selected-hover-background-color: #E3DDDF;
+    --controller-background-color: #e9e4e1; /* e3dbda at 50% opacity on f0ede9 bg */
+    --controller-text-color: #4A4C4E;
+    --controller-text-hover-color: #143649;
+    --controller-selected-color: #2D3134;
+    --controller-selected-background-color: #f0dfce;
+    --controller-hover-background-color: #ded9d3;
+    --controller-selected-hover-background-color: #e3d2c4;
 
     /* Controller search colors */
     --controller-search-background-color: transparent;
-    --controller-search-focused-background-color: #ffffff;
-    --controller-search-match-color: #491D2E;
+    --controller-search-focused-background-color: #F6F5F2;
+    --controller-search-match-color: #005583;
 
     /* Controller top and bottom bar colors */
-    --controller-bar-text-color: #B2B0AE;
-    --controller-bar-text-hover-color: #E6C7CE;
-    --controller-bar-background-color: #2d2026;
+    --controller-bar-text-color: #A8A5A3;
+    --controller-bar-text-hover-color: #E1BCA0;
+    --controller-bar-background-color: #332A29;
 
       /*****************/
      /* Settings      */
@@ -73,18 +73,19 @@
     /* Settings Menu */
     --settings-menu-background-color: var(--controller-bar-background-color);
     --settings-menu-text-color: var(--controller-bar-text-color);
-    --settings-menu-icon-color: #9C747E;
+    --settings-menu-icon-color: #898C90;
 
     /* Settings Content */
     --settings-background-color: var(--controller-background-color);
     --settings-text-color: var(--controller-text-color);
-    --settings-setting-color: rgb(129, 77, 90);
-    --settings-setting-shadow: rgb(129, 77, 90, 0.16);
+    --settings-setting-off: #F6F3EF;
+    --settings-setting-on: var(--controller-search-match-color);
+    --settings-setting-shadow: #00558331;
 
       /*****************/
      /* Miscellaneous */
     /*****************/
 
     /* Scrollbar colour */
-    --scrollbar-color: rgba(0, 0, 0, 0.5);
+    --scrollbar-color: rgba(141, 126, 116, 0.6);
 }

--- a/app/frontend/src/themes/Blue on White.css
+++ b/app/frontend/src/themes/Blue on White.css
@@ -79,8 +79,9 @@
     /* Settings Content */
     --settings-background-color: var(--controller-background-color);
     --settings-text-color: var(--controller-text-color);
-    --settings-setting-color: #f50057;
-    --settings-setting-shadow: #f5005631;
+    --settings-setting-off: #fafafa;
+    --settings-setting-on: var(--controller-search-match-color);
+    --settings-setting-shadow: #0D47A131;
     
       /*****************/
      /* Miscellaneous */

--- a/app/frontend/src/themes/Blue on White.css
+++ b/app/frontend/src/themes/Blue on White.css
@@ -79,8 +79,8 @@
     /* Settings Content */
     --settings-background-color: var(--controller-background-color);
     --settings-text-color: var(--controller-text-color);
-    --settings-setting-off: #fafafa;
-    --settings-setting-on: var(--controller-search-match-color);
+    --settings-setting-off-color: #fafafa;
+    --settings-setting-on-color: var(--controller-search-match-color);
     --settings-setting-shadow: #0D47A131;
     
       /*****************/

--- a/app/frontend/src/themes/Darbar Sahib.css
+++ b/app/frontend/src/themes/Darbar Sahib.css
@@ -84,8 +84,8 @@
     /* Settings Content */
     --settings-background-color: var(--controller-background-color);
     --settings-text-color: var(--controller-text-color);
-    --settings-setting-off: #fafafa;
-    --settings-setting-on: var(--controller-search-match-color);
+    --settings-setting-off-color: #fafafa;
+    --settings-setting-on-color: var(--controller-search-match-color);
     --settings-setting-shadow: #0D47A131;
 
       /*****************/

--- a/app/frontend/src/themes/Darbar Sahib.css
+++ b/app/frontend/src/themes/Darbar Sahib.css
@@ -6,7 +6,7 @@
     /* Display background */
     --display-background-color: #0C297B;
     --display-background-image: url('/themes/images/darbar-sahib.jpg');
-    --display-background-size: auto 100%;
+    --display-background-size: auto 110%;
 
     /* Display line colours */
     --display-line-1-color: #ffffff;

--- a/app/frontend/src/themes/Darbar Sahib.css
+++ b/app/frontend/src/themes/Darbar Sahib.css
@@ -84,8 +84,9 @@
     /* Settings Content */
     --settings-background-color: var(--controller-background-color);
     --settings-text-color: var(--controller-text-color);
-    --settings-setting-color: #f50057;
-    --settings-setting-shadow: #f5005631;
+    --settings-setting-off: #fafafa;
+    --settings-setting-on: var(--controller-search-match-color);
+    --settings-setting-shadow: #0D47A131;
 
       /*****************/
      /* Miscellaneous */

--- a/app/frontend/src/themes/Day.css
+++ b/app/frontend/src/themes/Day.css
@@ -78,8 +78,8 @@
     /* Settings Content */
     --settings-background-color: var(--controller-background-color);
     --settings-text-color: var(--controller-text-color);
-    --settings-setting-off: #fafafa;
-    --settings-setting-on: var(--controller-search-match-color);
+    --settings-setting-off-color: #fafafa;
+    --settings-setting-on-color: var(--controller-search-match-color);
     --settings-setting-shadow: #0D47A131;
 
       /*****************/

--- a/app/frontend/src/themes/Day.css
+++ b/app/frontend/src/themes/Day.css
@@ -78,8 +78,9 @@
     /* Settings Content */
     --settings-background-color: var(--controller-background-color);
     --settings-text-color: var(--controller-text-color);
-    --settings-setting-color: #f50057;
-    --settings-setting-shadow: #f5005631;
+    --settings-setting-off: #fafafa;
+    --settings-setting-on: var(--controller-search-match-color);
+    --settings-setting-shadow: #0D47A131;
 
       /*****************/
      /* Miscellaneous */

--- a/app/frontend/src/themes/Night.css
+++ b/app/frontend/src/themes/Night.css
@@ -83,8 +83,9 @@
     /* Settings Content */
     --settings-background-color: var(--controller-background-color);
     --settings-text-color: var(--controller-text-color);
-    --settings-setting-color: #f50057;
-    --settings-setting-shadow: #f5005631;
+    --settings-setting-off: #616161;
+    --settings-setting-on: var(--controller-search-match-color);
+    --settings-setting-shadow: #ffd18031;
 
       /*****************/
      /* Miscellaneous */

--- a/app/frontend/src/themes/Night.css
+++ b/app/frontend/src/themes/Night.css
@@ -83,8 +83,8 @@
     /* Settings Content */
     --settings-background-color: var(--controller-background-color);
     --settings-text-color: var(--controller-text-color);
-    --settings-setting-off: #616161;
-    --settings-setting-on: var(--controller-search-match-color);
+    --settings-setting-off-color: #616161;
+    --settings-setting-on-color: var(--controller-search-match-color);
     --settings-setting-shadow: #ffd18031;
 
       /*****************/

--- a/app/frontend/src/themes/Philosophiae.css
+++ b/app/frontend/src/themes/Philosophiae.css
@@ -78,7 +78,8 @@
     /* Settings Content */
     --settings-background-color: var(--controller-background-color);
     --settings-text-color: var(--controller-text-color);
-    --settings-setting-color: #b88c4a;
+    --settings-setting-off: #E9E8E7;
+    --settings-setting-on: #b88c4a;
     --settings-setting-shadow: #b88c4a2a;
 
       /*****************/

--- a/app/frontend/src/themes/Philosophiae.css
+++ b/app/frontend/src/themes/Philosophiae.css
@@ -78,8 +78,8 @@
     /* Settings Content */
     --settings-background-color: var(--controller-background-color);
     --settings-text-color: var(--controller-text-color);
-    --settings-setting-off: #E9E8E7;
-    --settings-setting-on: #b88c4a;
+    --settings-setting-off-color: #E9E8E7;
+    --settings-setting-on-color: #b88c4a;
     --settings-setting-shadow: #b88c4a2a;
 
       /*****************/

--- a/app/frontend/src/themes/Yellow on Blue.css
+++ b/app/frontend/src/themes/Yellow on Blue.css
@@ -78,8 +78,8 @@
     /* Settings Content */
     --settings-background-color: var(--controller-background-color);
     --settings-text-color: var(--controller-text-color);
-    --settings-setting-off: #fafafa;
-    --settings-setting-on: var(--controller-search-match-color);
+    --settings-setting-off-color: #fafafa;
+    --settings-setting-on-color: var(--controller-search-match-color);
     --settings-setting-shadow: #274dc431;
 
       /*****************/

--- a/app/frontend/src/themes/Yellow on Blue.css
+++ b/app/frontend/src/themes/Yellow on Blue.css
@@ -78,6 +78,9 @@
     /* Settings Content */
     --settings-background-color: var(--controller-background-color);
     --settings-text-color: var(--controller-text-color);
+    --settings-setting-off: #fafafa;
+    --settings-setting-on: var(--controller-search-match-color);
+    --settings-setting-shadow: #274dc431;
 
       /*****************/
      /* Miscellaneous */


### PR DESCRIPTION
This should change the color of the loader, the pop up selectors, as well as hover items in said pop up selector. In addition Avani theme was updated to move away from purple and more towards red while also shifting to blue and yellow-red accents.

Image of new Avani:
![image](https://user-images.githubusercontent.com/14130567/67651938-329a9180-f919-11e9-8fe5-21fcbe67262c.png)

Image of new Night:
![image](https://user-images.githubusercontent.com/14130567/67651957-46de8e80-f919-11e9-819a-9b8975002f09.png)

Also fixed sources in Avani (#233):
![image](https://user-images.githubusercontent.com/14130567/67651999-72fa0f80-f919-11e9-99f0-75c5d2677e4f.png)
