### PR TITLE
build(ci): custom code-signing Windows script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,7 @@ jobs:
     <<: *build
     executor:
       name: windows/default
+      shell: powershell.exe Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope LocalMachine
     environment:
       USE_HARD_LINKS: false
       PLATFORM_FLAG: "w"
@@ -99,6 +100,7 @@ jobs:
     <<: *publish
     executor:
       name: windows/default
+      shell: powershell.exe Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope LocalMachine
     environment:
       USE_HARD_LINKS: false
       PLATFORM_FLAG: "w"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
     <<: *build
     executor:
       name: windows/default
-      shell: cmd.exe
+      shell: bash.exe
     environment:
       USE_HARD_LINKS: false
       PLATFORM_FLAG: "w"
@@ -100,7 +100,7 @@ jobs:
     <<: *publish
     executor:
       name: windows/default
-      shell: cmd.exe
+      shell: bash.exe
     environment:
       USE_HARD_LINKS: false
       PLATFORM_FLAG: "w"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
     <<: *build
     executor:
       name: windows/default
-      shell: powershell.exe
+      shell: cmd.exe
     environment:
       USE_HARD_LINKS: false
       PLATFORM_FLAG: "w"
@@ -100,7 +100,7 @@ jobs:
     <<: *publish
     executor:
       name: windows/default
-      shell: powershell.exe
+      shell: cmd.exe
     environment:
       USE_HARD_LINKS: false
       PLATFORM_FLAG: "w"
@@ -112,13 +112,11 @@ workflows:
       - lint
       - build-windows:
           pre-steps:
-            - run: Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope LocalMachine
             - run: npm install --global --production windows-build-tools --vs2015
           requires:
             - lint
       - publish-windows:
           pre-steps:
-            - run: Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope LocalMachine
             - run: npm install --global --production windows-build-tools --vs2015
           requires:
             - build-windows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,6 @@ jobs:
     <<: *build
     executor:
       name: windows/default
-      shell: powershell.exe Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope LocalMachine
     environment:
       USE_HARD_LINKS: false
       PLATFORM_FLAG: "w"
@@ -100,7 +99,6 @@ jobs:
     <<: *publish
     executor:
       name: windows/default
-      shell: powershell.exe Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope LocalMachine
     environment:
       USE_HARD_LINKS: false
       PLATFORM_FLAG: "w"
@@ -112,11 +110,13 @@ workflows:
       - lint
       - build-windows:
           pre-steps:
+            - run: Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope LocalMachine
             - run: npm install --global --production windows-build-tools --vs2015
           requires:
             - lint
       - publish-windows:
           pre-steps:
+            - run: Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope LocalMachine
             - run: npm install --global --production windows-build-tools --vs2015
           requires:
             - build-windows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,7 @@ jobs:
     <<: *build
     executor:
       name: windows/default
+      shell: powershell.exe
     environment:
       USE_HARD_LINKS: false
       PLATFORM_FLAG: "w"
@@ -99,6 +100,7 @@ jobs:
     <<: *publish
     executor:
       name: windows/default
+      shell: powershell.exe
     environment:
       USE_HARD_LINKS: false
       PLATFORM_FLAG: "w"

--- a/hooks/sign-windows.js
+++ b/hooks/sign-windows.js
@@ -25,6 +25,7 @@ exports.default = async ( { path, name } ) => {
   const command = [
     [ `"${SIGN_TOOL_PATH}"` ],
     [ 'sign' ],
+    [ '/sm' ],
     [ '/t', `"${TIMESTAMP_SERVER}"` ],
     [ '/f', `"${certPath}"` ],
     [ '/d', `"${name}"` ],

--- a/hooks/sign-windows.js
+++ b/hooks/sign-windows.js
@@ -1,36 +1,37 @@
 const { execSync } = require( 'child_process' )
-const { writeFileSync, unlinkSync } = require( 'fs' )
-const { tmpdir } = require( 'os' )
 
 const {
-  WIN_CSC_LINK,
-  WIN_CSC_KEY_PASSWORD,
   SIGN_TOOL_PATH = 'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\x64\\signtool.exe',
   TIMESTAMP_SERVER = 'http://timestamp.digicert.com',
 } = process.env
 
 const SITE = 'https://shabados.com'
 
-const certificate = Buffer.from( WIN_CSC_LINK, 'base64' )
+const importPfx = ( certPath, password ) => {
+  const command = [
+    [ 'certutil' ],
+    [ '-user' ],
+    [ '-f' ],
+    [ '-p', `"${password}"` ],
+    [ '-importPfx', 'My', `"${certPath}"`, 'NoRoot' ],
+  ].map( sub => sub.join( ' ' ) ).join( ' ' )
 
-exports.default = async ( { path, name } ) => {
-  if ( !WIN_CSC_LINK ) return
+  try {
+    execSync( command, { stdio: 'inherit' } )
+  } catch {
+    console.error( 'Unable to import certificate' )
+  }
+}
 
-  const isFile = WIN_CSC_LINK.includes( 'file://' )
-
-  const certPath = isFile ? WIN_CSC_LINK.replace( 'file://', '' ) : `${tmpdir()}\\cert.pfx`
-
-  if ( !isFile ) writeFileSync( certPath, certificate )
-
+const signBinary = ( path, name ) => {
   const command = [
     [ `"${SIGN_TOOL_PATH}"` ],
     [ 'sign' ],
-    [ '/sm' ],
+    [ '/a' ],
+    [ '/s', 'My' ],
     [ '/t', `"${TIMESTAMP_SERVER}"` ],
-    [ '/f', `"${certPath}"` ],
     [ '/d', `"${name}"` ],
     [ '/du', `"${SITE}"` ],
-    [ '/p', `"${WIN_CSC_KEY_PASSWORD}"` ],
     [ `"${path}"` ],
   ].map( sub => sub.join( ' ' ) ).join( ' ' )
 
@@ -39,6 +40,11 @@ exports.default = async ( { path, name } ) => {
   } catch {
     console.error( `Signing ${path} failed` )
   }
+}
 
-  if ( !isFile ) unlinkSync( certPath )
+exports.default = ( { path, name, cscInfo: { file, password } = {} } ) => {
+  if ( !file ) return
+
+  importPfx( file, password )
+  signBinary( path, name, file )
 }

--- a/hooks/sign-windows.js
+++ b/hooks/sign-windows.js
@@ -10,7 +10,6 @@ const SITE = 'https://shabados.com'
 const importPfx = ( certPath, password ) => {
   const command = [
     [ 'certutil' ],
-    [ '-user' ],
     [ '-f' ],
     [ '-p', `"${password}"` ],
     [ '-importPfx', 'My', `"${certPath}"`, 'NoRoot' ],
@@ -29,6 +28,7 @@ const signBinary = ( path, name ) => {
     [ 'sign' ],
     [ '/a' ],
     [ '/s', 'My' ],
+    [ '/sm' ],
     [ '/t', `"${TIMESTAMP_SERVER}"` ],
     [ '/d', `"${name}"` ],
     [ '/du', `"${SITE}"` ],

--- a/hooks/sign-windows.js
+++ b/hooks/sign-windows.js
@@ -1,0 +1,39 @@
+const { execSync } = require( 'child_process' )
+const { writeFileSync, unlinkSync } = require( 'fs' )
+const { tmpdir } = require( 'os' )
+
+const {
+  WIN_CSC_LINK,
+  WIN_CSC_KEY_PASSWORD,
+  SIGN_TOOL_PATH = 'C:\\Program Files (x86)\\Windows Kits\\10\\signtool.exe',
+  TIMESTAMP_SERVER = 'http://timestamp.digicert.com',
+} = process.env
+
+const SITE = 'https://shabados.com'
+
+const certificate = Buffer.from( WIN_CSC_LINK, 'base64' )
+
+exports.default = async ( { path, name } ) => {
+  if ( !WIN_CSC_LINK ) return
+
+  const isFile = WIN_CSC_LINK.includes( 'file://' )
+
+  const certPath = isFile ? WIN_CSC_LINK.replace( 'file://', '' ) : `${tmpdir()}\\cert.pfx`
+
+  if ( !isFile ) writeFileSync( certPath, certificate )
+
+  const command = [
+    [ `"${SIGN_TOOL_PATH}"` ],
+    [ 'sign' ],
+    [ '/t', `"${TIMESTAMP_SERVER}"` ],
+    [ '/f', `"${certPath}"` ],
+    [ '/d', `"${name}"` ],
+    [ '/du', `"${SITE}"` ],
+    [ '/p', `"${WIN_CSC_KEY_PASSWORD}"` ],
+    [ `"${path}"` ],
+  ].map( sub => sub.join( ' ' ) ).join( ' ' )
+
+  execSync( command, { stdio: 'inherit' } )
+
+  if ( !isFile ) unlinkSync( certPath )
+}

--- a/hooks/sign-windows.js
+++ b/hooks/sign-windows.js
@@ -33,7 +33,11 @@ exports.default = async ( { path, name } ) => {
     [ `"${path}"` ],
   ].map( sub => sub.join( ' ' ) ).join( ' ' )
 
-  execSync( command, { stdio: 'inherit' } )
+  try {
+    execSync( command, { stdio: 'inherit' } )
+  } catch {
+    console.error( `Signing ${path} failed` )
+  }
 
   if ( !isFile ) unlinkSync( certPath )
 }

--- a/hooks/sign-windows.js
+++ b/hooks/sign-windows.js
@@ -5,7 +5,7 @@ const { tmpdir } = require( 'os' )
 const {
   WIN_CSC_LINK,
   WIN_CSC_KEY_PASSWORD,
-  SIGN_TOOL_PATH = 'C:\\Program Files (x86)\\Windows Kits\\10\\signtool.exe',
+  SIGN_TOOL_PATH = 'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\x64\\signtool.exe',
   TIMESTAMP_SERVER = 'http://timestamp.digicert.com',
 } = process.env
 

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     },
     "win": {
       "artifactName": "Shabad.OS-Setup-${version}.${ext}",
+      "sign": "./hooks/sign-windows.js",
       "target": [
         {
           "target": "nsis",


### PR DESCRIPTION
CircleCI's Windows user account does not give access to importing certificates into the `Current User` store. Thus, they must be imported to `Local Machine` (which ironically, requires elevated priviledges, but still works).