### PR TITLE
Release 2.0.3-beta.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ jobs:
           name: Tag Sentry release
           command: |
             # Get version
-            VERSION=$(cat app/package.json | jq .version)
+            VERSION=$(cat app/package.json | jq -r .version)
             # Create Sentry release
             sentry-cli releases new -p desktop-backend -p desktop-frontend $VERSION
             # Tag commits against release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,17 +119,16 @@ jobs:
           name: Download JQ
           command: apk --no-cache add jq
       - run:
-          name: Extract version
-          command: VERSION=$(cat app/package.json | jq .version)
-      - run:
-          name: Create Sentry release
-          command: sentry-cli releases new -p desktop-backend -p desktop-frontend $VERSION
-      - run:
-          name: Tag commits against release
-          command: sentry-cli releases set-commits --auto $VERSION
-      - run:
-          name: Finalise Sentry release
-          command: sentry-cli releases finalize $VERSION
+          name: Tag Sentry release
+          command: |
+            # Get version
+            VERSION=$(cat app/package.json | jq .version)
+            # Create Sentry release
+            sentry-cli releases new -p desktop-backend -p desktop-frontend $VERSION
+            # Tag commits against release
+            sentry-cli releases set-commits --auto $VERSION
+            # Finalise Sentry release
+            sentry-cli releases finalize $VERSION
 
 ## Workflow
 

--- a/app/electron/esm-wrapper.js
+++ b/app/electron/esm-wrapper.js
@@ -2,6 +2,9 @@
 
 const [ ,, entry = 'entry' ] = process.argv
 
+// Disable the ESM cache
+process.env.ESM_DISABLE_CACHE = 1
+
 // Patch require to allow for ES6 imports
 require = require( 'esm' )( module )
 

--- a/app/frontend/src/lib/controller.js
+++ b/app/frontend/src/lib/controller.js
@@ -17,7 +17,11 @@ class Controller extends EventEmitter {
     super()
 
     // Setup WebSocket connection to server
-    this.socket = new ReconnectingWebSocket( WS_URL )
+    this.socket = new ReconnectingWebSocket( WS_URL, null, {
+      reconnectionDelayGrowFactor: 1,
+      minReconnectionDelay: 300 + Math.random() * 200,
+      connectionTimeout: 1000,
+    } )
     this.socket.addEventListener( 'open', this.onOpen )
     this.socket.addEventListener( 'close', this.onClose )
     this.socket.addEventListener( 'message', this.onMessage )

--- a/app/lib/analytics.js
+++ b/app/lib/analytics.js
@@ -5,8 +5,9 @@
 
 /* eslint-disable class-methods-use-this */
 import * as Sentry from '@sentry/node'
-import { readJSON } from 'fs-extra'
 import { cpus, freemem, totalmem, platform, networkInterfaces } from 'os'
+
+import { version } from '../package.json'
 
 import logger from './logger'
 import settings from './settings'
@@ -34,7 +35,6 @@ class Analytics {
     logger.info( 'Enabling Sentry error reporting' )
 
     // Set the sentry release
-    const { version } = await readJSON( 'package.json', 'utf-8' )
     const release = `${SENTRY_PROJECT}@${version}`
 
     Sentry.init( { dsn: SENTRY_DSN, release } )

--- a/app/lib/analytics.js
+++ b/app/lib/analytics.js
@@ -21,8 +21,6 @@ class Analytics {
    * Loads Sentry.
    */
   async initialise() {
-    if ( isDev || !settings.get( 'system.serverAnalytics' ) ) return
-
     await this.initSentry()
   }
 
@@ -31,6 +29,8 @@ class Analytics {
    * ! Cannot be disabled without a restart.
    */
   async initSentry() {
+    if ( isDev || !settings.get( 'system.serverAnalytics' ) ) return
+
     logger.info( 'Enabling Sentry error reporting' )
 
     // Set the sentry release

--- a/app/lib/error.js
+++ b/app/lib/error.js
@@ -5,6 +5,8 @@ import { sendToElectron } from './utils'
 const portOccupied = () => {
   sendToElectron( 'ready' )
   logger.warn( 'Another instance is running on port 1699, quitting backend (the UI will connect to the existing instance instead).' )
+
+  process.exit( 0 )
 }
 
 const knownErrors = {
@@ -12,14 +14,18 @@ const knownErrors = {
 }
 
 // Handle any errors by logging and sending it to Sentry
-export const handleError = error => {
-  // If error is known and ok, log a warning message
+export const handleError = ( exitIfUnknown = true ) => error => {
+  // If error is known, handle it differently
   const knownError = knownErrors[ error.code ]
   if ( knownError ) {
     knownError( error )
     return
   }
 
+  // Log the error, and quit the process
   logger.error( error )
   analytics.sendException( error )
+
+  // Quit the server with an error if unknown error
+  if ( exitIfUnknown ) process.exit( 1 )
 }

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shabados/backend",
-  "version": "2.0.3",
+  "version": "2.0.4-beta.1",
   "description": "Shabad OS",
   "main": "electron/esm-wrapper.js",
   "scripts": {

--- a/app/server.js
+++ b/app/server.js
@@ -113,6 +113,7 @@ async function main() {
   if ( !isDev ) initialiseUpdater( sessionManager )
 }
 
-process.on( 'uncaughtException', handleError )
+process.on( 'uncaughtException', handleError() )
+process.on( 'unhandledRejection', handleError( false ) )
 
-export default main().catch( handleError )
+export default main().catch( handleError() )


### PR DESCRIPTION
- More reliable error handling
- Restart backend on crash
- Smaller reconnection timeout for frontend WebSockets
- Fix Sentry not initialising correctly in backend due to silent error
- *Catch unhhandled rejections and log them* <-- This is most likely why we haven't got logs for a bunch of bugs we can somewhat reproduce