### PR TITLE
Release 2.2.0

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@shabados/backend",
-  "version": "2.1.1-beta.2",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shabados/backend",
-  "version": "2.2.0-beta.2",
+  "version": "2.2.0",
   "description": "Shabad OS",
   "main": "electron/esm-wrapper.js",
   "scripts": {


### PR DESCRIPTION
- Fix timestamp formatting in navigator and history, fixes #341
- Do not log to stdout in production, fixes #331 (long usage crash)
- Performance improvements with memoisation and refactoring to contexts + hooks
- History performance improvements
- Ensure Sentry crash logs are flushed before restarting backend
- Asa Di Vaar auto-select enhancements (auto-select limited to within Pauri or Chant)