### PR TITLE
fix(frontend/presenter): add explicit height for ios webkit

### DIFF
--- a/app/frontend/src/Presenter/Line.css
+++ b/app/frontend/src/Presenter/Line.css
@@ -144,6 +144,10 @@
   color: var(--display-vishraam-light-color) !important;
 }
 
+.next-line, .previous-line {
+  min-height: min-content;
+}
+
 /* ------------------------------------
    Simple lines - remove animations
    ------------------------------------ */


### PR DESCRIPTION
this is not required for most modern browsers on desktop. this may have also affected safari on macOS. without this, it would try to fit all the lines into the space for next-lines/previous-lines. can be visualized by reverting this commit and specifying hidden overflow for next line.

close #420