### PR TITLE
fix(frontend/controller): highlight full words in search

### DIFF
--- a/app/frontend/src/Controller/Search.js
+++ b/app/frontend/src/Controller/Search.js
@@ -233,7 +233,12 @@ const Search = ( { updateFocus, register, focused } ) => {
 
     // Separate the line into words before the match, the match, and after the match
     const getMatches = highlightMatches( gurmukhi )
-    const [ beforeMatch, match, afterMatch ] = getMatches( gurmukhi, searchedValue, mode )
+    const [ beforeMatch, match, afterMatch ] = getMatches(
+      gurmukhi,
+      // trim to get rid of extra spaces
+      searchedValue.trim(),
+      mode,
+    )
     const [ translitBeforeMatch, translitMatch, translitAfterMatch ] = getMatches(
       transliteration,
       searchedValue,

--- a/app/frontend/src/Controller/Search.js
+++ b/app/frontend/src/Controller/Search.js
@@ -88,7 +88,6 @@ const highlightFirstLetterMatches = ( line, query ) => {
 
 /**
  * Separates the line into words before the first match, the first match, and after the match.
- * TODO: Extend this logic to find every match, rather than simply the first one.
  * @param value the full line.
  * @param input the string inputted by the user.
  * @param mode the type of search being performed, either first word or full word.

--- a/app/frontend/src/Controller/Search.js
+++ b/app/frontend/src/Controller/Search.js
@@ -58,15 +58,13 @@ const getSearchParams = searchQuery => {
 
 const highlightFullWordMatches = ( line, query ) => {
   const foundPosition = line.search( query )
-  const wordEndPosition = line.indexOf( ' ', foundPosition + query.length )
-  const wordStartPosition = line.lastIndexOf( ' ', foundPosition )
+  const matchStartPosition = line.lastIndexOf( ' ', foundPosition )
 
-  // If the match occurs in the first word, no space will be detected, and wordStartPosition
-  // will be -1. In this case, we want to start at the beginning of the line.
-  const matchStartPosition = wordStartPosition === -1 ? 0 : wordStartPosition
+  const wordEndPosition = line.indexOf( ' ', foundPosition + query.length )
   // If the match finishes in the last word, no space will be deteced, and wordEndPosition
   // will be -1. In this case, we want to end at the last position in the line.
-  const matchEndPosition = wordEndPosition === -1 ? foundPosition + query.length : wordEndPosition
+  const matchEndPosition = wordEndPosition === -1 ? line.length - 1 : wordEndPosition
+
   return [
     line.substring( 0, matchStartPosition ),
     line.substring( matchStartPosition, matchEndPosition ),

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@shabados/backend",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@shabados/backend",
-  "version": "2.7.0",
+  "version": "2.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
## Summary
Closes https://github.com/ShabadOS/desktop/issues/170. Does not change the functionality of the `firstLetter` search highlighting, but modifies the `fullWord` highlighting to include all words.

### Before
<img width="478" alt="Screen Shot 2020-05-15 at 11 45 09 PM" src="https://user-images.githubusercontent.com/2431994/82264039-2c5e1800-9932-11ea-919f-21bf9dba6de9.png">

### After

<img width="482" alt="Screen Shot 2020-05-18 at 10 14 55 AM" src="https://user-images.githubusercontent.com/2431994/82264069-3b44ca80-9932-11ea-8c83-300bb3f8bcf5.png">
<img width="478" alt="Screen Shot 2020-05-18 at 12 38 39 PM" src="https://user-images.githubusercontent.com/2431994/82264071-3b44ca80-9932-11ea-974a-70c9c8f26ff8.png">

### First letter search still works
<img width="486" alt="Screen Shot 2020-05-18 at 6 13 22 PM" src="https://user-images.githubusercontent.com/2431994/82264674-59f79100-9933-11ea-8371-e29cc436f718.png">


## How was this tested?
I tried the following test cases:
1. The word is at the beginning of the line.
2. The word comes after a special character.
3. Trailing space after the word.
4. Ensured the first letter search still worked.
Happy to write unit tests once those exist (if they exist).

## Other odds and ends
I didn't have permission to push to ShabadOS/desktop, and the instructions said to fork so that's what I did - not as well versed with the workflow so let me know if I need to change things.

I was surprised at some of the eslint rules, especially the extraneous semicolon being enforced.

## Reviewers
@saihaj @Harjot1Singh 