### PR TITLE
fix(frontend/controller): hide gui arrow buttons for mobile browsers

### DIFF
--- a/app/frontend/src/Controller/Navigator.css
+++ b/app/frontend/src/Controller/Navigator.css
@@ -17,6 +17,6 @@
   color: red !important;
 }
 
-.mobile.app .navigator-controls .info-button {
+.mobile.app .navigator-controls .arrow {
   display: none;
 }

--- a/app/frontend/src/Controller/Navigator.js
+++ b/app/frontend/src/Controller/Navigator.js
@@ -262,6 +262,7 @@ export const Bar = ( { onHover } ) => {
     <div className="navigator-controls">
       <ToolbarButton
         name="Up"
+        className="arrow"
         icon={faChevronUp}
         onMouseEnter={() => onHover( 'Previous Line' )}
         onMouseLeave={resetHover}
@@ -272,6 +273,7 @@ export const Bar = ( { onHover } ) => {
 
       <ToolbarButton
         name="Down"
+        className="arrow"
         icon={faChevronDown}
         onMouseEnter={() => onHover( 'Next Line' )}
         onMouseLeave={resetHover}


### PR DESCRIPTION
older smartphone's cannot fit all the icons available in the navigator activity

fix #491

---

## Summary

### Before
<img src="https://user-images.githubusercontent.com/14130567/82578045-dec3f400-9b59-11ea-89f0-fb7c0fd64241.png" width="240">

### After
<img src="https://user-images.githubusercontent.com/14130567/82578054-e1264e00-9b59-11ea-92a2-b08de552ce36.png" width="240">

## Tests

Tested on iPhone 5 320x568 via inspect tool and Pixel 3a via physical device using Firefox

## Time / PM

Took about 5 minutes. The PR took an additional 5 minutes. 😂 