### PR TITLE
fix(frontend/controller): convert search query to ascii when required

### DIFF
--- a/app/frontend/src/Controller/Search.js
+++ b/app/frontend/src/Controller/Search.js
@@ -44,7 +44,9 @@ const getSearchParams = searchQuery => {
   // Extract anchors and search query
   const [ , anchor, query ] = searchQuery.match( searchRegex )
 
-  const inputValue = toAscii( query )
+  let hasMoreThanAscii = [...query].some(char => char.charCodeAt(0) > 127);
+
+  const inputValue = hasMoreThanAscii ? toAscii( query ) : query
 
   // Get search type from anchor char, if any
   const type = SEARCH_ANCHORS[ anchor ] || SEARCH_TYPES.firstLetter

--- a/app/frontend/src/lib/controller.js
+++ b/app/frontend/src/lib/controller.js
@@ -107,7 +107,7 @@ class Controller extends EventEmitter {
    * @param type The type of search (first-letter/full-word).
    * @param options Additional options to pass.
    */
-  search = ( query, type, options = {} ) => this.sendJSON( `search:${type}`, { ...options, query: toAscii( query ) } )
+  search = ( query, type, options = {} ) => this.sendJSON( `search:${type}`, { ...options, query: [...query].some(char => char.charCodeAt(0) > 127) ? toAscii( query ) : query } )
 
   /**
    * Convenience method for setting the line.


### PR DESCRIPTION
otherwise it will unnecessarily move around sihari accent character (ASCII i)

fix #166

---

## Summary

The search query was unnecessarily being converted to ascii which caused it to move the accent character (sihari). Making sure the query is not ascii before converting it resolved it.

### Before
![before](https://user-images.githubusercontent.com/14130567/82584827-0a97a780-9b63-11ea-938b-be7ce162156d.gif)

### After
![after](https://user-images.githubusercontent.com/14130567/82584721-e0de8080-9b62-11ea-9ff3-0dae815a8efa.gif)

## Tests

Tried ascii and unicode on desktop and mobile phone.

Tried all sorts of various characters on keyboard without having the render mess up (and hopefully assuming that applies to query as well, no easy way to test all those manually)

## Other

I am unsure if there is a way to refactor such that I don't have to use the same conditional in two separate locations

## PM / Time

Took between 30-45 minutes