### PR TITLE
fix(backend): compare like types for nextLineId

### DIFF
--- a/app/lib/SessionManager.js
+++ b/app/lib/SessionManager.js
@@ -196,7 +196,7 @@ class SessionManager {
       this.onMainLine( client, mainLineId || newLineId )
 
       // Next line is either first line, or line after
-      const { id: nextLineId } = lines[ 0 ] === newLineId ? lines[ 1 ] : lines[ 0 ]
+      const { id: nextLineId } = lines[ 0 ].id === newLineId ? lines[ 1 ] : lines[ 0 ]
       this.onNextLine( client, prevNextLineId || nextLineId )
     }
 


### PR DESCRIPTION
fixes #351

## Summary

Simple fix to compare IDs correctly. Before it was comparing an array with a string.

## Tests

Tested with first and second lines of various shabads. Also tested with Asa Ki Vaar. Noticed that the `<<` symbol is not shown in AKV. Can't remember if that was how it was before, but regardless it still looks okay and functions the same. You always can see where the jump will take you.

## TTR

I won't lie, this took a lot longer than I expected. Took 60 minutes to read the code base and hone in on the area. Another 30 minutes to figure out how to debug in VS Code. And then finally another 15 to resolve and test various shabads.