### PR TITLE
fix(frontend): reload settings when default options have been modified

### DIFF
--- a/app/frontend/src/App.js
+++ b/app/frontend/src/App.js
@@ -29,6 +29,8 @@ const ScreenReader = lazy( () => import( './ScreenReader' ) )
 const Presenter = lazy( () => import( './Presenter' ) )
 const Settings = lazy( () => import( './Settings' ) )
 
+const loadSettings = () => merge( { local: controller.readSettings() }, DEFAULT_OPTIONS )
+
 class App extends PureComponent {
   components = [
     [ Overlay, OVERLAY_URL ],
@@ -61,7 +63,7 @@ class App extends PureComponent {
       shabad: null,
       recommendedSources: {},
       writers: {},
-      settings: merge( { local: controller.readSettings() }, DEFAULT_OPTIONS ),
+      settings: loadSettings(),
     }
   }
 
@@ -87,7 +89,8 @@ class App extends PureComponent {
       .then( ( { recommended: recommendedSources } ) => {
         //* Update default options and settings with fetched recommended sources
         DEFAULT_OPTIONS.local.sources = recommendedSources
-        this.setState( ( { settings } ) => ( { recommendedSources, settings } ) )
+        //! Re-load settings since we've modified DEFAULT_OPTIONS directly
+        this.setState( { recommendedSources, settings: loadSettings() } )
       } )
 
     // Get writers


### PR DESCRIPTION
### Summary of PR
Reloads settings when the sources have been retrieved from the backend. Fixes race conditions which end up resulting in the translations not rendering in both the overlay and presenter, since React is not aware that the change happened.

### Tests for unexpected behavior
- Set network to "Fast 3G" in network inspector and reload. Translations do not work originally.

### Time spent on PR
15 mins

### Linked issues
Fixes #535 

### Reviewers
@bhajneet 