### PR TITLE
fix(frontend/settings): update source settings when option is changed

### DIFF
--- a/app/frontend/src/Settings/Sources.js
+++ b/app/frontend/src/Settings/Sources.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { shape, objectOf, string, number, func } from 'prop-types'
+import { shape, objectOf, string, number } from 'prop-types'
 
 import {
   ExpansionPanel,
@@ -14,6 +14,7 @@ import { faChevronDown } from '@fortawesome/free-solid-svg-icons'
 
 import Loader from '../shared/Loader'
 import { BACKEND_URL } from '../lib/consts'
+import controller from '../lib/controller'
 
 import { ResetButton } from './DynamicOptions'
 import { Dropdown as Select } from './SettingComponents'
@@ -23,7 +24,7 @@ import './Sources.css'
 /**
  * View to configure source content, such as translations.
  */
-const Sources = ( { sources: currentSources, setSettings } ) => {
+const Sources = ( { sources: currentSources, device } ) => {
   const [ languages, setLanguages ] = useState()
   const [ { sources, recommended }, setSources ] = useState( {} )
 
@@ -92,7 +93,7 @@ const Sources = ( { sources: currentSources, setSettings } ) => {
                               values={translationSources[ id ].map( (
                                 ( { nameEnglish: name, id: value } ) => ( { name, value } )
                               ) )}
-                              onChange={( { target: { value } } ) => setSettings( {
+                              onChange={( { target: { value } } ) => controller.setSettings( {
                                 sources: {
                                   [ sourceId ]: {
                                     translationSources: {
@@ -102,7 +103,7 @@ const Sources = ( { sources: currentSources, setSettings } ) => {
                                     },
                                   },
                                 },
-                              } )}
+                              }, device )}
                             />
                           ) : (
                             <Typography variant="body2">{translationSources[ id ][ 0 ].nameEnglish}</Typography>
@@ -125,6 +126,7 @@ const Sources = ( { sources: currentSources, setSettings } ) => {
 }
 
 Sources.propTypes = {
+  device: string.isRequired,
   sources: objectOf( shape( {
     nameEnglish: string.isRequired,
     nameGurmukhi: string.isRequired,
@@ -133,7 +135,6 @@ Sources.propTypes = {
       nameEnglish: string.isRequired,
     } ) ),
   } ) ).isRequired,
-  setSettings: func.isRequired,
 }
 
 export default Sources

--- a/app/frontend/src/Settings/index.js
+++ b/app/frontend/src/Settings/index.js
@@ -221,7 +221,7 @@ const Settings = () => {
             path={`${SETTINGS_DEVICE_URL}/hotkeys`}
             render={() => ( <Hotkeys shortcuts={SHORTCUTS} keys={hotkeys} device={device} /> )}
           />
-          <Route path={`${SETTINGS_DEVICE_URL}/sources`} render={() => <Sources sources={selectedDeviceSettings.sources} />} />
+          <Route path={`${SETTINGS_DEVICE_URL}/sources`} render={() => <Sources sources={selectedDeviceSettings.sources} device={device} />} />
           <Route path={`${SETTINGS_DEVICE_URL}/*`} render={() => <DynamicOptions device={device} group={group} />} />
 
           {/* Server setting routes */}


### PR DESCRIPTION
### Summary of PR
Fixes the updating of source options. Due to a regression, no `setSettings` function was supplied to the `Sources` component, thus, it was unable to propagate any user changes.

### Tests for unexpected behavior
✔ Change sources and observe changes on presenter 

### Time spent on PR
2 minutes

### Linked issues
Fixes #538

### Reviewers
@bhajneet 