### PR TITLE
fix(frontend/settings): sliders lag on mobile phone

### DIFF
--- a/app/frontend/src/Settings/DynamicOptions.js
+++ b/app/frontend/src/Settings/DynamicOptions.js
@@ -3,7 +3,7 @@ import { string, shape, node, bool } from 'prop-types'
 
 import { Typography, Grid } from '@material-ui/core'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { debounce } from 'lodash'
+import { throttle } from 'lodash'
 
 import { OPTIONS, DEFAULT_OPTIONS, PRIVACY_TYPES, FLAT_OPTION_GROUPS } from '../lib/options'
 import controller from '../lib/controller'
@@ -103,7 +103,7 @@ const DynamicOptions = ( { device, group } ) => {
               {...props}
               option={option}
               value={value}
-              onChange={debounce( setSettings, 100, { leading: true } )}
+              onChange={throttle( setSettings, 100, { leading: true } )}
               disabled={isDisabled}
             />
           </OptionSlot>

--- a/app/frontend/src/Settings/DynamicOptions.js
+++ b/app/frontend/src/Settings/DynamicOptions.js
@@ -3,6 +3,7 @@ import { string, shape, node, bool } from 'prop-types'
 
 import { Typography, Grid } from '@material-ui/core'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { debounce } from 'lodash'
 
 import { OPTIONS, DEFAULT_OPTIONS, PRIVACY_TYPES, FLAT_OPTION_GROUPS } from '../lib/options'
 import controller from '../lib/controller'
@@ -102,7 +103,7 @@ const DynamicOptions = ( { device, group } ) => {
               {...props}
               option={option}
               value={value}
-              onChange={setSettings}
+              onChange={debounce( setSettings, 100, { leading: true } )}
               disabled={isDisabled}
             />
           </OptionSlot>


### PR DESCRIPTION
### Summary of PR
Add `debounce` to settings `onChange`

### Tests for unexpected behavior
Sliders on mobile work more smoothly and same experience on desktop

### Time spent on PR
30 minutes

### Linked issues
Fix #282 

### Reviewers
@Harjot1Singh @bhajneet 