### PR TITLE
feat(frontend/settings): add os.release to about page and sentry logger

### DIFF
--- a/app/frontend/src/Settings/About.js
+++ b/app/frontend/src/Settings/About.js
@@ -18,6 +18,7 @@ const aboutFields = [
   [ 'databaseVersion', 'Shabad OS Database Version' ],
   [ 'hostname', 'Shabad OS Host' ],
   [ 'platform', 'Platform' ],
+  [ 'release', 'Release' ],
   [ 'arch', 'Architecture' ],
   [ 'cpus', 'CPU(s)' ],
 ]

--- a/app/lib/analytics.js
+++ b/app/lib/analytics.js
@@ -5,7 +5,7 @@
 
 /* eslint-disable class-methods-use-this */
 import * as Sentry from '@sentry/node'
-import { cpus, freemem, totalmem, platform, networkInterfaces } from 'os'
+import { cpus, freemem, totalmem, platform, release, networkInterfaces } from 'os'
 
 import { version } from '../package.json'
 
@@ -51,6 +51,7 @@ class Analytics {
         freeMemory: freemem(),
         totalMemory: totalmem(),
         platform: platform(),
+        release: release(),
         networkInterfaces: networkInterfaces(),
       } )
 

--- a/app/lib/api.js
+++ b/app/lib/api.js
@@ -1,6 +1,6 @@
 import { Router } from 'express'
 import { basename, join } from 'path'
-import { hostname, platform, arch, cpus } from 'os'
+import { hostname, platform, release, arch, cpus } from 'os'
 import { readJSON } from 'fs-extra'
 
 import { CUSTOM_THEMES_FOLDER, APP_FOLDER, FRONTEND_THEMES_FOLDER, DATABASE_FOLDER, CUSTOM_OVERLAY_THEMES_FOLDER, FRONTEND_OVERLAY_THEMES_FOLDER } from './consts'
@@ -33,6 +33,7 @@ api.get( '/about', ( _, res ) => Promise.all( [
   arch: arch(),
   cpus: `${cpus().length}x ${cpus()[ 0 ].model}`,
   platform: platform(),
+  release: release(),
   addresses: getNetworkedAddresses(),
 } ) ) )
 


### PR DESCRIPTION
### Summary of PR
Add release info to about page, this info can also be used in loggers so logs will reflect which os is running more effectively

![image](https://user-images.githubusercontent.com/14130567/83196664-4ce45a00-a10a-11ea-9ee2-937f645072ea.png)

### Tests for unexpected behavior
- since adding a feature, I don't think there could be anything broken by something as simple as this

### Time spent on PR
13 mins of reading docs, 1 minute of coding, 1 minute of PR = 15 mins

### Linked issues
Fix #365

### Reviewers
@Harjot1Singh 