### PR TITLE
fix(frontend/controller): use custom first and last hotkeys in navigator

### DIFF
--- a/app/frontend/src/Controller/Navigator.js
+++ b/app/frontend/src/Controller/Navigator.js
@@ -178,6 +178,10 @@ const NavigatorNavigationHotkeys = withNavigationHotkeys( {
   lineKeys: true,
   clickOnFocus: true,
   wrapAround: false,
+  keymap: {
+    first: null,
+    last: null,
+  },
 } )( Navigator )
 
 // Wrap NavigationHotkeys first so that it takes precedence

--- a/app/frontend/src/lib/keyMap.js
+++ b/app/frontend/src/lib/keyMap.js
@@ -116,50 +116,47 @@ export const COPY_SHORTCUTS = decorateGroup( {
 
 // Navigator-specific hotkeys
 export const NAVIGATOR_SHORTCUTS = decorateGroup( {
-  nextLine: {
-    name: 'Go Next Line',
-    description: 'Advances to the next line.',
-    sequences: [ 'down', 'right', 'tab', 'PageDown', 'l' ],
-  },
-  previousLine: {
-    name: 'Go Previous Line',
-    description: 'Goes to the previous line.',
-    sequences: [ 'up', 'left', 'shift+tab', 'PageUp', 'j' ],
-  },
-  firstLine: {
-    name: 'Jump First Line',
-    description: 'Jumps to first line. If on first line, jumps to last line of previous shabad.',
-    sequences: [ 'ctrl+up', 'home' ],
-  },
-  lastLine: {
-    name: 'Jump Last Line',
-    description: 'Jumps to last line. If on last line, jumps to last line of previous shabad.',
-    sequences: [ 'ctrl+down', 'end' ],
-  },
-  autoToggle: {
-    name: 'Auto Jump',
-    description: 'Jumps to main line, or to the next available line.',
-    sequences: [ 'space', 'b' ],
-  },
-  setMainLine: {
-    name: 'Set Main Line',
-    description: 'Sets the main line.',
-    sequences: [ 'ctrl+space' ],
-  },
-  goJumpLine: {
-    name: 'Jump Next Non-Main Line',
-    description: 'Jumps to the next line if on the main line.',
-    sequences: [ 'shift+.' ],
-  },
-  goMainLine: {
-    name: 'Jump Main Line',
-    description: 'Jumps to the main line.',
-    sequences: [ 'shift+,' ],
-  },
   restoreLine: {
     name: 'Activate Line',
     description: 'Activates the line prior to a cleared screen',
     sequences: [ 'enter', 'return' ],
+  },
+  nextLine: {
+    name: 'Next Line',
+    sequences: [ 'down', 'right', 'tab', 'PageDown', 'l' ],
+  },
+  previousLine: {
+    name: 'Previous Line',
+    sequences: [ 'up', 'left', 'shift+tab', 'PageUp', 'j' ],
+  },
+  firstLine: {
+    name: 'First Line',
+    description: 'Go to first line. If on first line, then go to last line of previous entry.',
+    sequences: [ 'ctrl+up', 'home' ],
+  },
+  lastLine: {
+    name: 'Last Line',
+    description: 'Go to last line. If on last line, then go to first line of next entry.',
+    sequences: [ 'ctrl+down', 'end' ],
+  },
+  autoToggle: {
+    name: 'Autoselect Line',
+    description: 'Go to main line or next jump line.',
+    sequences: [ 'space', 'b' ],
+  },
+  setMainLine: {
+    name: 'Reset Main Line',
+    sequences: [ 'ctrl+space' ],
+  },
+  goMainLine: {
+    description: 'Go to main line without changing position of next jump line.',
+    name: 'Skip to Main Line',
+    sequences: [ 'shift+,' ],
+  },
+  goJumpLine: {
+    name: 'Skip to Jump Line',
+    description: 'Go to the non-main, jump line.',
+    sequences: [ 'shift+.' ],
   },
 } )( 'Navigator' )
 


### PR DESCRIPTION
### Summary of PR
the custom hotkeys for first / last in navigator were lower priority than the default navigation hotkeys used in other activities

Also updated the settings page:
![image](https://user-images.githubusercontent.com/14130567/83331143-3fda7e80-a262-11ea-8d9a-c67063a9ad05.png)

### Tests for unexpected behavior
- used different shabads as tests
- confirmed not breaking banis
- tried in other activities for whatever reason

### Time spent on PR
About 3 hours. Spent about 30 minutes figuring out where the issue was coming from. Then another 2 hours trying to fix it. Then spent 5 minutes on copying the solution being used in `search.js` to `navigator.js` Remaining time was spent on thinking through hotkey names/descriptions for settings.

### Linked issues
Fix #504 

### Reviewers
@Harjot1Singh 