### PR TITLE
fix(frontend): copy on first hotkey stroke

### DIFF
--- a/app/frontend/src/lib/hooks.js
+++ b/app/frontend/src/lib/hooks.js
@@ -60,9 +60,12 @@ export const useCopyToClipboard = () => {
   const truncate = input => ( input.length > 30 ? `${input.substring( 0, 30 )}...` : input )
 
   const { enqueueSnackbar } = useSnackbar()
-
   return ( text, fallback = 'No text to copy' ) => {
-    if ( text ) copy( text )
+    if ( text ) {
+      // Double copying due to bug: https://github.com/sudodoki/copy-to-clipboard/issues/90
+      copy( text )
+      copy( text )
+    }
 
     enqueueSnackbar(
       text ? `Copied "${truncate( text )}" to clipboard` : fallback,


### PR DESCRIPTION
### Summary of PR
Work around for sudodoki/copy-to-clipboard#90

### Tests for unexpected behavior
* Works on very first hotkey stroke
* Also works when you change shabads 

### Time spent on PR
4 hours

### Linked issues
Fix #437 

### Reviewers
@Harjot1Singh 