### PR TITLE
fix: correct overlay port for dev

### DIFF
--- a/app/frontend/src/Settings/OverlaySettings.js
+++ b/app/frontend/src/Settings/OverlaySettings.js
@@ -3,7 +3,7 @@ import React, { useState, useEffect } from 'react'
 import { Grid, Typography } from '@material-ui/core'
 import { faShareSquare } from '@fortawesome/free-solid-svg-icons'
 
-import { BACKEND_URL, BACKEND_PORT, isElectron } from '../lib/consts'
+import { BACKEND_URL, OVERLAY_PORT, isElectron } from '../lib/consts'
 import controller from '../lib/controller'
 
 import CopyButton from './CopyButton'
@@ -55,7 +55,7 @@ const OverlaySettings = () => {
         <Grid item {...slotSizes.name}><Typography>Overlay URL</Typography></Grid>
         <Grid item {...slotSizes.option} align="center">
           {Object.entries( addresses ).map( ( [ name, address ] ) => (
-            <CopyButton style={{ textAlign: 'center' }} copyText={`http://${address}:${BACKEND_PORT}/overlay`}>{`${address}:${BACKEND_PORT}/overlay (${name})`}</CopyButton>
+            <CopyButton style={{ textAlign: 'center' }} copyText={`http://${address}:${OVERLAY_PORT}/overlay`}>{`${address}:${OVERLAY_PORT}/overlay (${name})`}</CopyButton>
           ) )}
         </Grid>
       </OptionGrid>

--- a/app/frontend/src/lib/consts.js
+++ b/app/frontend/src/lib/consts.js
@@ -24,6 +24,7 @@ export const BACKEND_HOST = window.location.hostname || 'localhost'
 export const BACKEND_PORT = !isDev ? 1699 : 42425
 export const BACKEND_URL = `http://${BACKEND_HOST}:${BACKEND_PORT}`
 export const WS_URL = `ws://${BACKEND_HOST}:${BACKEND_PORT}`
+export const OVERLAY_PORT = !isDev ? 1699 : 3000
 
 /* Sentry Data Source Name */
 export const SENTRY_DSN = 'https://51b714c1e7544cba86efb2cad85152ff@sentry.io/1363390'


### PR DESCRIPTION
### Summary of PR
On dev the port for overlays should be same as frontend and that is `3000` and for production `1699`

### Tests for unexpected behavior
**Before**
![Kapture 2020-06-16 at 14 03 41](https://user-images.githubusercontent.com/44710980/84817257-3f6c1280-afda-11ea-991e-9106a8ed4e77.gif)

**After**
![Kapture 2020-06-16 at 14 02 01](https://user-images.githubusercontent.com/44710980/84816773-ffa52b00-afd9-11ea-82e1-7f1010cc2f5f.gif)


### Time spent on PR
2 mins for fix and don't know for how long I have been complaining

### Reviewers
@Harjot1Singh 