### PR TITLE
feat(electron): add version number to splash screen

### DIFF
--- a/app/electron/electron-wrapper.js
+++ b/app/electron/electron-wrapper.js
@@ -5,6 +5,7 @@ import logger from '../lib/logger'
 import { isDev } from '../lib/consts'
 import { createMainWindow, createNonMainWindows, closeNonMainWindows, createWindow, createSplashScreen, getMainWindow, getDisplayWindows } from './window'
 import { setBeta, initUpdates, checkUpdates, UPDATER_ERRORS } from './updates'
+import { version } from '../package.json'
 
 
 let splashScreen
@@ -14,6 +15,9 @@ app.on( 'ready', () => {
 
   logger.info( 'Loading splashscreen' )
   splashScreen = createSplashScreen()
+  splashScreen.customProps = {
+    version,
+  }
 } )
 
 const onSettingsChange = ( { system } ) => {

--- a/app/electron/electron-wrapper.js
+++ b/app/electron/electron-wrapper.js
@@ -15,7 +15,7 @@ app.on( 'ready', () => {
 
   logger.info( 'Loading splashscreen' )
   splashScreen = createSplashScreen()
-  splashScreen.customProps = {
+  splashScreen.globals = {
     version,
   }
 } )

--- a/app/electron/splashscreen/index.html
+++ b/app/electron/splashscreen/index.html
@@ -19,8 +19,8 @@
     </div>
     <script>
       const electron = require('electron');
-      const currentWindow = electron.remote.getCurrentWindow();
-      document.getElementById('start-message').innerHTML = `Starting v${currentWindow.customProps.version}`
+      const { customProps: { version } } = electron.remote.getCurrentWindow();
+      document.getElementById('start-message').innerHTML = `Starting v${version}`
     </script>
 </body>
 

--- a/app/electron/splashscreen/index.html
+++ b/app/electron/splashscreen/index.html
@@ -18,8 +18,8 @@
       <span id="start-message">Starting</span>
     </div>
     <script>
-      const electron = require('electron');
-      const { customProps: { version } } = electron.remote.getCurrentWindow();
+      const electron = require( 'electron' )
+      const { globals: { version } } = electron.remote.getCurrentWindow();
       document.getElementById('start-message').innerHTML = `Starting v${version}`
     </script>
 </body>

--- a/app/electron/splashscreen/index.html
+++ b/app/electron/splashscreen/index.html
@@ -15,8 +15,13 @@
       <span>Shabad OS</span>
     </div>
     <div class="message">
-      <span>Starting</span>
+      <span id="start-message">Starting</span>
     </div>
+    <script>
+      const electron = require('electron');
+      const currentWindow = electron.remote.getCurrentWindow();
+      document.getElementById('start-message').innerHTML = `Starting v${currentWindow.customProps.version}`
+    </script>
 </body>
 
 </html>


### PR DESCRIPTION
### Summary of PR
Add version number to splash screen

**Before**
<img width="548" alt="image" src="https://user-images.githubusercontent.com/44710980/87462086-fe651f00-c5d4-11ea-9a56-63cc1a90876e.png">

**After**
<img width="548" alt="image" src="https://user-images.githubusercontent.com/44710980/87462046-f0af9980-c5d4-11ea-8868-824faa13ca96.png">

### Time spent on PR
40 minutes

### Linked issues
Fixes #490

### Reviewers
@Harjot1Singh @bhajneet 