### PR TITLE
fix(frontend/settings): add descriptive name for all displays toggle

### DIFF
--- a/app/frontend/src/lib/options.js
+++ b/app/frontend/src/lib/options.js
@@ -115,7 +115,7 @@ export const OPTIONS = {
   displayAnalytics: { name: 'Display Usage Analytics', icon: faChartPie, type: OPTION_TYPES.toggle, privacy: PRIVACY_TYPES.local },
   private: { name: 'Private Settings', icon: faLock, type: OPTION_TYPES.toggle, privacy: PRIVACY_TYPES.private },
   launchOnStartup: { name: 'Launch On Startup', icon: faDoorOpen, type: OPTION_TYPES.toggle, privacy: PRIVACY_TYPES.global },
-  multipleDisplays: { name: 'All Displays', icon: faDesktop, type: OPTION_TYPES.toggle, privacy: PRIVACY_TYPES.global },
+  multipleDisplays: { name: 'Launch on All Displays', icon: faDesktop, type: OPTION_TYPES.toggle, privacy: PRIVACY_TYPES.global },
   fullscreenOnLaunch: { name: 'Launch In Fullscreen', icon: faExpandArrowsAlt, type: OPTION_TYPES.toggle, privacy: PRIVACY_TYPES.global },
   serverAnalytics: { name: 'Server Usage Analytics', icon: faChartPie, type: OPTION_TYPES.toggle, privacy: PRIVACY_TYPES.global },
   automaticUpdates: { name: 'Automatic Updates', icon: faSync, type: OPTION_TYPES.toggle, privacy: PRIVACY_TYPES.global },


### PR DESCRIPTION
### Summary of PR
Rename `Settings`>`System Options`>`All Displays` to `Launch on All Displays`

**Before**
<img width="912" alt="image" src="https://user-images.githubusercontent.com/44710980/87463157-9d3e4b00-c5d6-11ea-948c-ddc35fbffec3.png">

**After**
<img width="912" alt="image" src="https://user-images.githubusercontent.com/44710980/87463136-96173d00-c5d6-11ea-842a-83f7da85f06e.png">


### Time spent on PR
5 minutes -> 30 seconds for fix and rest for git related

### Linked issues
Fixes #366

### Reviewers
@bhajneet @Harjot1Singh 