### PR TITLE
build: add vscode plugin recommendations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ tmux*
 .file_tags.kaktmp
 .kak.tags.namecache
 tags
-.vscode*
+.vscode/*
 nohup.out
 *.sass-cache*
 styles/main.css.*
@@ -20,3 +20,4 @@ settings.json
 dist/
 .nyc_output/
 coverage/
+!.vscode/extensions.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,5 @@
     "recommendations": [
       "dbaeumer.vscode-eslint",
       "github.vscode-pull-request-github",
-      "vivaxy.vscode-conventional-commits",
     ]
   }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+    "recommendations": [
+      "dbaeumer.vscode-eslint",
+      "github.vscode-pull-request-github",
+      "vivaxy.vscode-conventional-commits",
+    ]
+  }


### PR DESCRIPTION
### Summary of PR
Add VSCode plugins in `.vscode/extensions.json`. Explanation of why `.gitignore` only excludes `.vscode/extensions.json` is [here](https://github.com/ShabadOS/desktop/issues/196#issuecomment-659457270).
### Time spent on PR
10 minutes

### Linked issues
Fix #196 

### Reviewers
@Harjot1Singh @bhajneet 

Note: Push changes here if you would like to suggest more plugins